### PR TITLE
Relaxes concurrent-ruby dependency to allow minor bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,8 @@ PATH
   specs:
     pubnub (5.3.4)
       addressable (>= 2.0.0)
-      concurrent-ruby (~> 1.1.5)
-      concurrent-ruby-edge (~> 0.5.0)
+      concurrent-ruby (~> 1.1)
+      concurrent-ruby-edge (~> 0.5)
       dry-validation (~> 1.0)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 2.2.0, < 3)

--- a/pubnub.gemspec
+++ b/pubnub.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_dependency 'addressable', '>= 2.0.0'
-  spec.add_dependency 'concurrent-ruby', '~> 1.1.5'
-  spec.add_dependency 'concurrent-ruby-edge', '~> 0.5.0'
+  spec.add_dependency 'concurrent-ruby', '~> 1.1'
+  spec.add_dependency 'concurrent-ruby-edge', '~> 0.5'
   spec.add_dependency 'dry-validation', '~> 1.0'
   spec.add_dependency 'httpclient', '~> 2.8', '>= 2.8.3'
   spec.add_dependency 'json', '>= 2.2.0', '< 3'


### PR DESCRIPTION
This relaxes the `concurrent-ruby` (and `-edge`) requirement such that our monolith can bump Rails to 7.1 (which requires `concurrent-ruby` 1.3 via ActiveSupport). 

Part of the testing here will be on the monoliths side to make sure all of the PubNub-y goodness still works alright for what we need.